### PR TITLE
Set cursor to the end of the command whenever traversing history

### DIFF
--- a/js/events.js
+++ b/js/events.js
@@ -102,7 +102,9 @@ var history = [], history_index = 0;
 
     var set_command = function(cmd) {
       editor.getSession().setValue(cmd);
+      editor.getSelection().moveCursorFileEnd();
       resize_textarea(editor, '#editor');
+      
     };
 
     var resize_textarea = function(editor, selector) {


### PR DESCRIPTION
This will make sure that the cursor is at the end of the line whenever you hit up or down, which behaves the same way native irb does.
