### PR TITLE
Use https for scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
 <head>
   <title>irb</title>
   <link href="css/screen.css" media="screen" rel="stylesheet" type="text/css" />
-  <script src="http://cdnjs.cloudflare.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
-  <script src="http://d1n0x3qji82z53.cloudfront.net/src-min-noconflict/ace.js" type="text/javascript" charset="utf-8"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
+  <script src="https://d1n0x3qji82z53.cloudfront.net/src-min-noconflict/ace.js" type="text/javascript" charset="utf-8"></script>
   <script src="js/jquery.simplemodal.js"></script>
   <script src="js/events.js"></script>
   <script src="js/webruby.js"></script>


### PR DESCRIPTION
The app is currently broken because the Javascript is loaded over http instead of https, and the browser blocks the scripts for security.
